### PR TITLE
DCA11Y-1222 config changes for releasing to Atlassian repository

### DIFF
--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -81,10 +81,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
       </plugin>
     </plugins>

--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>frontend-plugins</artifactId>
     <groupId>com.atlassian.frontend-maven-plugin-fork</groupId>
-    <version>1.15.0-atlassian-testrelease-1</version>
+    <version>1.15.0-atlassian-1-SNAPSHOT</version>
   </parent>
 
   <artifactId>frontend-maven-plugin</artifactId>

--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>frontend-plugins</artifactId>
     <groupId>com.github.eirslett</groupId>
-    <version>1.15.0-atlassian-1-SNAPSHOT</version>
+    <version>1.15.0-atlassian-testrelease-1</version>
   </parent>
 
   <artifactId>frontend-maven-plugin</artifactId>

--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>frontend-plugins</artifactId>
-    <groupId>com.github.eirslett</groupId>
+    <groupId>com.atlassian.frontend-maven-plugin-fork</groupId>
     <version>1.15.0-atlassian-testrelease-1</version>
   </parent>
 
@@ -24,7 +24,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.github.eirslett</groupId>
+      <groupId>com.atlassian.frontend-maven-plugin-fork</groupId>
       <artifactId>frontend-plugin-core</artifactId>
       <version>${project.parent.version}</version>
     </dependency>

--- a/frontend-maven-plugin/src/it/bun-integration/pom.xml
+++ b/frontend-maven-plugin/src/it/bun-integration/pom.xml
@@ -10,7 +10,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.github.eirslett</groupId>
+                <groupId>com.atlassian.frontend-maven-plugin-fork</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
                 <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
                 <version>@project.version@</version>

--- a/frontend-maven-plugin/src/it/custom-install-directory/pom.xml
+++ b/frontend-maven-plugin/src/it/custom-install-directory/pom.xml
@@ -10,7 +10,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.github.eirslett</groupId>
+                <groupId>com.atlassian.frontend-maven-plugin-fork</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
                 <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
                 <version>@project.version@</version>

--- a/frontend-maven-plugin/src/it/custom-working-directory/pom.xml
+++ b/frontend-maven-plugin/src/it/custom-working-directory/pom.xml
@@ -10,7 +10,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.github.eirslett</groupId>
+                <groupId>com.atlassian.frontend-maven-plugin-fork</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
                 <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
                 <version>@project.version@</version>

--- a/frontend-maven-plugin/src/it/example project/pom.xml
+++ b/frontend-maven-plugin/src/it/example project/pom.xml
@@ -11,7 +11,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.github.eirslett</groupId>
+        <groupId>com.atlassian.frontend-maven-plugin-fork</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
         <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
         <version>@project.version@</version>

--- a/frontend-maven-plugin/src/it/node-provided-npm/pom.xml
+++ b/frontend-maven-plugin/src/it/node-provided-npm/pom.xml
@@ -10,7 +10,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.github.eirslett</groupId>
+                <groupId>com.atlassian.frontend-maven-plugin-fork</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
                 <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
                 <version>@project.version@</version>

--- a/frontend-maven-plugin/src/it/npx-integration/pom.xml
+++ b/frontend-maven-plugin/src/it/npx-integration/pom.xml
@@ -10,7 +10,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.github.eirslett</groupId>
+                <groupId>com.atlassian.frontend-maven-plugin-fork</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
                 <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
                 <version>@project.version@</version>

--- a/frontend-maven-plugin/src/it/pnpm-integration/pom.xml
+++ b/frontend-maven-plugin/src/it/pnpm-integration/pom.xml
@@ -10,7 +10,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.github.eirslett</groupId>
+                <groupId>com.atlassian.frontend-maven-plugin-fork</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
                 <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
                 <version>@project.version@</version>

--- a/frontend-maven-plugin/src/it/yarn-berry-integration/pom.xml
+++ b/frontend-maven-plugin/src/it/yarn-berry-integration/pom.xml
@@ -10,7 +10,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.github.eirslett</groupId>
+                <groupId>com.atlassian.frontend-maven-plugin-fork</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
                 <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
                 <version>@project.version@</version>

--- a/frontend-maven-plugin/src/it/yarn-integration/pom.xml
+++ b/frontend-maven-plugin/src/it/yarn-integration/pom.xml
@@ -10,7 +10,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.github.eirslett</groupId>
+                <groupId>com.atlassian.frontend-maven-plugin-fork</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
                 <!-- NB! Set <version> to the latest released version of frontend-maven-plugin, like in README.md -->
                 <version>@project.version@</version>

--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>frontend-plugins</artifactId>
         <groupId>com.github.eirslett</groupId>
-        <version>1.15.0-atlassian-1-SNAPSHOT</version>
+        <version>1.15.0-atlassian-testrelease-1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>frontend-plugins</artifactId>
         <groupId>com.atlassian.frontend-maven-plugin-fork</groupId>
-        <version>1.15.0-atlassian-testrelease-1</version>
+        <version>1.15.0-atlassian-1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -77,10 +77,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
         </plugins>

--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>frontend-plugins</artifactId>
-        <groupId>com.github.eirslett</groupId>
+        <groupId>com.atlassian.frontend-maven-plugin-fork</groupId>
         <version>1.15.0-atlassian-testrelease-1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,9 @@
     </licenses>
 
     <scm>
-        <url>https://github.com/atlassian/frontend-maven-plugin</url>
-        <connection>scm:git:https://github.com/atlassian/frontend-maven-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:atlassian/frontend-maven-plugin.git</developerConnection>
+        <url>https://github.com/atlassian-forks/frontend-maven-plugin</url>
+        <connection>scm:git:https://github.com/atlassian-forks/frontend-maven-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:atlassian-forks/frontend-maven-plugin.git</developerConnection>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -72,26 +72,6 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
-                <executions>
-                    <execution>
-                        <id>default-deploy</id>
-                        <phase>deploy</phase>
-                        <!-- By default, this is the phase deploy goal will bind to -->
-                        <goals>
-                            <goal>deploy</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <serverId>ossrh</serverId>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.eirslett</groupId>
+    <groupId>com.atlassian.frontend-maven-plugin-fork</groupId>
     <artifactId>frontend-plugins</artifactId>
     <version>1.15.0-atlassian-testrelease-1</version>
     <packaging>pom</packaging>
@@ -68,14 +68,6 @@
                     <releaseProfiles>release</releaseProfiles>
                     <branchName>master</branchName>
                     <goals>deploy</goals>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.1.1</version>
-                <configuration>
-                    <skip>true</skip>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.eirslett</groupId>
     <artifactId>frontend-plugins</artifactId>
-    <version>1.15.0-atlassian-1-SNAPSHOT</version>
+    <version>1.15.0-atlassian-testrelease-1</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.atlassian.frontend-maven-plugin-fork</groupId>
     <artifactId>frontend-plugins</artifactId>
-    <version>1.15.0-atlassian-testrelease-1</version>
+    <version>1.15.0-atlassian-1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,12 @@
     <version>1.15.0-atlassian-testrelease-1</version>
     <packaging>pom</packaging>
 
+    <parent>
+        <artifactId>central-pom</artifactId>
+        <groupId>com.atlassian.pom</groupId>
+        <version>6.3.8</version>
+    </parent>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <gpg.skip>true</gpg.skip>
@@ -116,18 +122,4 @@
             </plugins>
         </pluginManagement>
     </build>
-
-    <distributionManagement>
-        <repository>
-            <id>maven-atlassian-com</id>
-            <name>Atlassian Central Repository</name>
-            <url>https://packages.atlassian.com/maven/central</url>
-        </repository>
-        <snapshotRepository>
-            <id>maven-atlassian-com</id>
-            <name>Atlassian Central Snapshot Repository</name>
-            <url>https://packages.atlassian.com/maven/central-snapshot</url>
-        </snapshotRepository>
-    </distributionManagement>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -119,12 +119,14 @@
 
     <distributionManagement>
         <repository>
-            <id>atlassian-3rdparty</id>
-            <url>https://maven.atlassian.com/3rdparty</url>
+            <id>maven-atlassian-com</id>
+            <name>Atlassian Central Repository</name>
+            <url>https://packages.atlassian.com/maven/central</url>
         </repository>
         <snapshotRepository>
-            <id>atlassian-3rdparty-snapshot</id>
-            <url>https://maven.atlassian.com/3rdparty-snapshot</url>
+            <id>maven-atlassian-com</id>
+            <name>Atlassian Central Snapshot Repository</name>
+            <url>https://packages.atlassian.com/maven/central-snapshot</url>
         </snapshotRepository>
     </distributionManagement>
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**
In order to make our changes to the fork available for use in Atlassian projects, we want to publish to the Atlassian package repository.

This PR adds and modifies necessary configuration for that.

I followed [this internal guide](https://hello.atlassian.net/wiki/spaces/~278062200/pages/1407390489/HOW+TO+Do+a+manual+maven+artifact+release) from the local machine and tried until the deployment succeeded.

Another helpful guide: https://hello.atlassian.net/wiki/spaces/OSP/pages/791250012/HOWTO+Publish+an+open+source+project+on+Maven+Central

- changed groupId, because our repository mirrors the open-source releases to Maven Central, and we can only use `{com|io}.atlassian` prefixes for that.
- added central-pom from https://bitbucket.org/atlassian/parent-poms/ and removed explicit distributionManagement (the values in which additionally were obsolete at this point anyway)
- removed tagging for the sonatype - some kind of an external registry
- updated scm section (while there was no harm in keeping atlassian/frontend-maven-plugin because of a redirect, the more correct atlassian-fork/frontend-maven-plugin is used now)
- removed explicit mentions of maven-source-plugin because the command from the manual (`mvn source:jar javadoc:jar install`) didn't work with them: that plugin was being called twice and didn't like that
- removed the `skip=true` config to the deploy task. I hold a quaint notion that when a guy issues the "deploy" command, he expects the "deploy" command to execute.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Tests and Documentation**

<!-- Demonstrate the code is solid. Add a simple description to CHANGELOG.md and add some infos to README.md or Wiki, if necessary. -->
