### PR TITLE
DCA11Y-1145 Make project releaseable

### DIFF
--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>frontend-plugins</artifactId>
     <groupId>com.github.eirslett</groupId>
-    <version>1.15.0-atlassian-1-SNAPSHOT</version>
+    <version>1.15.0-atlassian-1-e31f82ca</version>
   </parent>
 
   <artifactId>frontend-maven-plugin</artifactId>

--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>frontend-plugins</artifactId>
     <groupId>com.github.eirslett</groupId>
-    <version>1.15.0-atlassian-1-e31f82ca</version>
+    <version>1.15.0-atlassian-1-SNAPSHOT</version>
   </parent>
 
   <artifactId>frontend-maven-plugin</artifactId>

--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.github.eirslett</groupId>
       <artifactId>frontend-plugin-core</artifactId>
-      <version>${project.version}</version>
+      <scope>compile</scope>
     </dependency>
 
     <dependency>

--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.github.eirslett</groupId>
       <artifactId>frontend-plugin-core</artifactId>
-      <version>${project.parent.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -79,14 +79,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
 

--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -73,17 +73,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>frontend-plugins</artifactId>
         <groupId>com.github.eirslett</groupId>
-        <version>1.15.0-atlassian-1-e31f82ca</version>
+        <version>1.15.0-atlassian-1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>frontend-plugins</artifactId>
         <groupId>com.github.eirslett</groupId>
-        <version>1.15.0-atlassian-1-SNAPSHOT</version>
+        <version>1.15.0-atlassian-1-e31f82ca</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>com.atlassian.pom</groupId>
-        <artifactId>public-pom</artifactId>
-        <version>6.3.8</version>
-    </parent>
-
     <groupId>com.github.eirslett</groupId>
     <artifactId>frontend-plugins</artifactId>
     <version>1.15.0-atlassian-1-SNAPSHOT</version>
@@ -16,9 +10,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <gpg.skip>true</gpg.skip>
         <java.version>1.8</java.version>
-
-        <!-- Must match the distribution management -->
-        <artifactory.target.repo>maven-3rdparty</artifactory.target.repo>
     </properties>
 
     <name>Frontend Plugins</name>

--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,9 @@
     </licenses>
 
     <scm>
-        <url>https://github.com/atlassian/frontend-maven-plugin</url>
-        <connection>scm:git:https://github.com/atlassian/frontend-maven-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:atlassian/frontend-maven-plugin.git</developerConnection>
+        <url>https://github.com/atlassian-forks/frontend-maven-plugin</url>
+        <connection>scm:git:https://github.com/atlassian-forks/frontend-maven-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:atlassian-forks/frontend-maven-plugin.git</developerConnection>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.eirslett</groupId>
     <artifactId>frontend-plugins</artifactId>
-    <version>1.15.0-atlassian-1-SNAPSHOT</version>
+    <version>1.15.0-atlassian-1-e31f82ca</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -64,26 +64,6 @@
                     <goals>deploy</goals>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
-                <executions>
-                    <execution>
-                        <id>default-deploy</id>
-                        <phase>deploy</phase>
-                        <!-- By default, this is the phase deploy goal will bind to -->
-                        <goals>
-                            <goal>deploy</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <serverId>ossrh</serverId>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.eirslett</groupId>
     <artifactId>frontend-plugins</artifactId>
-    <version>1.15.0-atlassian-1-SNAPSHOT</version>
+    <version>1.15.0-atlassian-1-0b42a3b</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.eirslett</groupId>
     <artifactId>frontend-plugins</artifactId>
-    <version>1.15.0-atlassian-1-e31f82ca</version>
+    <version>1.15.0-atlassian-1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -76,35 +76,6 @@
                         <target>1.8</target>
                     </configuration>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>3.3.0</version>
-                    <executions>
-                        <execution>
-                            <id>attach-sources</id>
-                            <goals>
-                                <goal>jar-no-fork</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.5.0</version>
-                    <configuration>
-                        <source>${maven.compiler.source}</source>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>attach-javadocs</id>
-                            <goals>
-                                <goal>jar</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -81,11 +81,11 @@
     <distributionManagement>
         <repository>
             <id>atlassian-3rdparty</id>
-            <url>https://maven.atlassian.com/3rdparty</url>
+            <url>https://packages.atlassian.com/maven/3rdparty</url>
         </repository>
         <snapshotRepository>
             <id>atlassian-3rdparty-snapshot</id>
-            <url>https://maven.atlassian.com/3rdparty-snapshot</url>
+            <url>https://packages.atlassian.com/maven/3rdparty-snapshot</url>
         </snapshotRepository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,14 +65,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.1.1</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
                 <version>1.6.13</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>com.atlassian.pom</groupId>
+        <artifactId>public-pom</artifactId>
+        <version>6.3.8</version>
+    </parent>
+
     <groupId>com.github.eirslett</groupId>
     <artifactId>frontend-plugins</artifactId>
     <version>1.15.0-atlassian-1-0b42a3b</version>
@@ -80,11 +86,11 @@
 
     <distributionManagement>
         <repository>
-            <id>atlassian-3rdparty</id>
+            <id>maven-atlassian-com</id>
             <url>https://packages.atlassian.com/maven/3rdparty</url>
         </repository>
         <snapshotRepository>
-            <id>atlassian-3rdparty-snapshot</id>
+            <id>maven-atlassian-com</id>
             <url>https://packages.atlassian.com/maven/3rdparty-snapshot</url>
         </snapshotRepository>
     </distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <gpg.skip>true</gpg.skip>
         <java.version>1.8</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <name>Frontend Plugins</name>
@@ -72,8 +70,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.11.0</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
                     </configuration>
                 </plugin>
             </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <gpg.skip>true</gpg.skip>
         <java.version>1.8</java.version>
+
+        <!-- Must match the distribution management -->
+        <artifactory.target.repo>maven-3rdparty</artifactory.target.repo>
     </properties>
 
     <name>Frontend Plugins</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.github.eirslett</groupId>
     <artifactId>frontend-plugins</artifactId>
-    <version>1.15.0-atlassian-1-0b42a3b</version>
+    <version>1.15.0-atlassian-1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -53,6 +53,21 @@
         <module>frontend-plugin-core</module>
         <module>frontend-maven-plugin</module>
     </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-plugin-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,32 @@
                         <target>${java.version}</target>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>copy-license</id>
+                            <phase>process-sources</phase>
+                            <goals>
+                                <goal>copy-resources</goal>
+                            </goals>
+                            <configuration>
+                                <outputDirectory>${project.build.outputDirectory}/META-INF</outputDirectory>
+                                <overwrite>true</overwrite>
+                                <resources>
+                                    <resource>
+                                        <directory>${user.dir}</directory>
+                                        <includes>
+                                            <include>LICENSE</include>
+                                        </includes>
+                                        <filtering>true</filtering>
+                                    </resource>
+                                </resources>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
This prepares the POMs to be releaseable in the same manner as we've done for Spring, Velocity, and Selenium forks we own in DC.