### PR TITLE
DCA11Y-1145 Sync to 1.15.1

### DIFF
--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>frontend-plugins</artifactId>
     <groupId>com.github.eirslett</groupId>
-    <version>1.15.0-atlassian-1-SNAPSHOT</version>
+    <version>1.15.1-atlassian-1-SNAPSHOT</version>
   </parent>
 
   <artifactId>frontend-maven-plugin</artifactId>
@@ -60,6 +60,12 @@
       <artifactId>jsr305</artifactId>
       <version>3.0.2</version>
       <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.5.1</version>
     </dependency>
   </dependencies>
 

--- a/frontend-maven-plugin/src/it/bun-integration/invoker.properties
+++ b/frontend-maven-plugin/src/it/bun-integration/invoker.properties
@@ -1,1 +1,1 @@
-invoker.os.family = !windows, unix, mac
+invoker.os.family = windows, unix, mac

--- a/frontend-maven-plugin/src/it/bun-integration/package-lock.json
+++ b/frontend-maven-plugin/src/it/bun-integration/package-lock.json
@@ -3,8 +3,15 @@
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "classnames": {
+  "packages": {
+    "": {
+      "name": "example",
+      "version": "0.0.1",
+      "dependencies": {
+        "classnames": "^2.3.2"
+      }
+    },
+    "node_modules/classnames": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
       "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="

--- a/frontend-maven-plugin/src/it/corepack-integration/.yarnrc.yml
+++ b/frontend-maven-plugin/src/it/corepack-integration/.yarnrc.yml
@@ -1,0 +1,3 @@
+enableGlobalCache: false
+
+nodeLinker: node-modules

--- a/frontend-maven-plugin/src/it/corepack-integration/package.json
+++ b/frontend-maven-plugin/src/it/corepack-integration/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "example",
+  "version": "0.0.1",
+  "dependencies": {
+    "less": "~3.0.2"
+  },
+  "packageManager": "yarn@4.1.1"
+}

--- a/frontend-maven-plugin/src/it/corepack-integration/pom.xml
+++ b/frontend-maven-plugin/src/it/corepack-integration/pom.xml
@@ -22,23 +22,23 @@
                 <executions>
 
                     <execution>
-                        <id>install bun runtime</id>
+                        <id>install node and corepack</id>
                         <goals>
-                            <goal>install-bun</goal>
+                            <goal>install-node-and-corepack</goal>
                         </goals>
                         <configuration>
-                            <bunVersion>v1.1.27</bunVersion>
+                            <nodeVersion>v20.12.2</nodeVersion>
+                            <corepackVersion>0.25.2</corepackVersion>
                         </configuration>
                     </execution>
 
                     <execution>
-                        <id>bun install</id>
+                        <id>yarn install</id>
                         <goals>
-                            <goal>bun</goal>
+                            <goal>corepack</goal>
                         </goals>
-                        <!-- Optional configuration which provides for running any npm command -->
                         <configuration>
-                            <arguments>install</arguments>
+                            <arguments>yarn install --no-immutable</arguments>
                         </configuration>
                     </execution>
 
@@ -46,5 +46,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/frontend-maven-plugin/src/it/corepack-integration/verify.groovy
+++ b/frontend-maven-plugin/src/it/corepack-integration/verify.groovy
@@ -1,0 +1,6 @@
+assert new File(basedir, 'target/node').exists() : "Node was not installed in the custom install directory";
+assert new File(basedir, 'node_modules').exists() : "Node modules were not installed in the base directory";
+assert new File(basedir, 'node_modules/less/package.json').exists() : "Less dependency has not been installed successfully";
+
+String buildLog = new File(basedir, 'build.log').text
+assert buildLog.contains('BUILD SUCCESS') : 'build was not successful'

--- a/frontend-maven-plugin/src/it/corepack-provided-integration/.yarnrc.yml
+++ b/frontend-maven-plugin/src/it/corepack-provided-integration/.yarnrc.yml
@@ -1,0 +1,3 @@
+enableGlobalCache: false
+
+nodeLinker: node-modules

--- a/frontend-maven-plugin/src/it/corepack-provided-integration/package.json
+++ b/frontend-maven-plugin/src/it/corepack-provided-integration/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "example",
+  "version": "0.0.1",
+  "dependencies": {
+    "less": "~3.0.2"
+  },
+  "packageManager": "yarn@4.1.1"
+}

--- a/frontend-maven-plugin/src/it/corepack-provided-integration/pom.xml
+++ b/frontend-maven-plugin/src/it/corepack-provided-integration/pom.xml
@@ -22,23 +22,22 @@
                 <executions>
 
                     <execution>
-                        <id>install bun runtime</id>
+                        <id>install node and corepack</id>
                         <goals>
-                            <goal>install-bun</goal>
+                            <goal>install-node-and-corepack</goal>
                         </goals>
                         <configuration>
-                            <bunVersion>v1.1.27</bunVersion>
+                            <nodeVersion>v20.12.2</nodeVersion>
                         </configuration>
                     </execution>
 
                     <execution>
-                        <id>bun install</id>
+                        <id>yarn install</id>
                         <goals>
-                            <goal>bun</goal>
+                            <goal>corepack</goal>
                         </goals>
-                        <!-- Optional configuration which provides for running any npm command -->
                         <configuration>
-                            <arguments>install</arguments>
+                            <arguments>yarn install --no-immutable</arguments>
                         </configuration>
                     </execution>
 
@@ -46,5 +45,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/frontend-maven-plugin/src/it/corepack-provided-integration/verify.groovy
+++ b/frontend-maven-plugin/src/it/corepack-provided-integration/verify.groovy
@@ -1,0 +1,6 @@
+assert new File(basedir, 'target/node').exists() : "Node was not installed in the custom install directory";
+assert new File(basedir, 'node_modules').exists() : "Node modules were not installed in the base directory";
+assert new File(basedir, 'node_modules/less/package.json').exists() : "Less dependency has not been installed successfully";
+
+String buildLog = new File(basedir, 'build.log').text
+assert buildLog.contains('BUILD SUCCESS') : 'build was not successful'

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/AbstractFrontendMojo.java
@@ -1,6 +1,8 @@
 package com.github.eirslett.maven.plugins.frontend.mojo;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.maven.lifecycle.LifecycleExecutionException;
@@ -10,6 +12,8 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.settings.Server;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.aether.RepositorySystemSession;
 
 import com.github.eirslett.maven.plugins.frontend.lib.FrontendException;
@@ -106,6 +110,37 @@ public abstract class AbstractFrontendMojo extends AbstractMojo {
         } else {
             getLog().info("Skipping execution.");
         }
+    }
+    
+    /** 
+     * Provides the HTTP-Headers from the server section of settings.xml.
+     * 
+     * @param server 
+     *           the &lt;server&gt; entry from the settings.xml
+     *           
+     * @return the mapping from the name of each configured HTTP header to its value,
+     *         an empty map if there is no such configuration
+     */
+    protected Map<String, String> getHttpHeaders(Server server) {
+        if (server == null || !(server.getConfiguration() instanceof Xpp3Dom)) {
+            return Collections.emptyMap();
+        }
+        
+        Xpp3Dom configuration = (Xpp3Dom) server.getConfiguration();
+        
+        Map<String, String> result = new HashMap<>();
+
+        Xpp3Dom httpHeaders = configuration.getChild("httpHeaders");
+        if (httpHeaders != null) {
+            for (Xpp3Dom property : httpHeaders.getChildren("property")) {
+                Xpp3Dom name = property.getChild("name");
+                Xpp3Dom value = property.getChild("value");
+                if (name != null && value != null) {
+                    result.put(name.getValue(), value.getValue());
+                }
+            }
+        }
+        return result;
     }
 
 }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/CorepackMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/CorepackMojo.java
@@ -1,0 +1,54 @@
+package com.github.eirslett.maven.plugins.frontend.mojo;
+
+import java.io.File;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
+import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
+
+@Mojo(name="corepack",  defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
+public final class CorepackMojo extends AbstractFrontendMojo {
+
+    /**
+     * corepack arguments. Default is "enable".
+     */
+    @Parameter(defaultValue = "enable", property = "frontend.corepack.arguments", required = false)
+    private String arguments;
+
+    @Parameter(property = "session", defaultValue = "${session}", readonly = true)
+    private MavenSession session;
+
+    @Component
+    private BuildContext buildContext;
+
+    @Component(role = SettingsDecrypter.class)
+    private SettingsDecrypter decrypter;
+
+    /**
+     * Skips execution of this mojo.
+     */
+    @Parameter(property = "skip.corepack", defaultValue = "${skip.corepack}")
+    private boolean skip;
+
+    @Override
+    protected boolean skipExecution() {
+        return this.skip;
+    }
+
+    @Override
+    public synchronized void execute(FrontendPluginFactory factory) throws TaskRunnerException {
+        File packageJson = new File(workingDirectory, "package.json");
+        if (buildContext == null || buildContext.hasDelta(packageJson) || !buildContext.isIncremental()) {
+            factory.getCorepackRunner().execute(arguments, environmentVariables);
+        } else {
+            getLog().info("Skipping corepack install as package.json unchanged");
+        }
+    }
+}

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallBunMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallBunMojo.java
@@ -50,7 +50,7 @@ public final class InstallBunMojo extends AbstractFrontendMojo {
         Server server = MojoUtils.decryptServer(this.serverId, this.session, this.decrypter);
         if (null != server) {
             factory.getBunInstaller(proxyConfig).setBunVersion(this.bunVersion).setUserName(server.getUsername())
-                    .setPassword(server.getPassword()).install();
+                    .setPassword(server.getPassword()).setHttpHeaders(getHttpHeaders(server)).install();
         } else {
             factory.getBunInstaller(proxyConfig).setBunVersion(this.bunVersion).install();
         }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndCorepackMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndCorepackMojo.java
@@ -1,0 +1,117 @@
+package com.github.eirslett.maven.plugins.frontend.mojo;
+
+import com.github.eirslett.maven.plugins.frontend.lib.CorepackInstaller;
+import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
+import com.github.eirslett.maven.plugins.frontend.lib.InstallationException;
+import com.github.eirslett.maven.plugins.frontend.lib.NodeInstaller;
+import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
+
+import java.util.Map;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
+import org.apache.maven.settings.Server;
+
+@Mojo(name="install-node-and-corepack", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
+public final class InstallNodeAndCorepackMojo extends AbstractFrontendMojo {
+
+    /**
+     * Where to download Node.js binary from. Defaults to https://nodejs.org/dist/
+     */
+    @Parameter(property = "nodeDownloadRoot", required = false)
+    private String nodeDownloadRoot;
+
+    /**
+     * Where to download corepack binary from. Defaults to https://registry.npmjs.org/corepack/-/
+     */
+    @Parameter(property = "corepackDownloadRoot", required = false, defaultValue = CorepackInstaller.DEFAULT_COREPACK_DOWNLOAD_ROOT)
+    private String corepackDownloadRoot;
+
+    /**
+     * The version of Node.js to install. IMPORTANT! Most Node.js version names start with 'v', for example 'v0.10.18'
+     */
+    @Parameter(property="nodeVersion", required = true)
+    private String nodeVersion;
+
+    /**
+     * The version of corepack to install. Note that the version string can optionally be prefixed with
+     * 'v' (i.e., both 'v1.2.3' and '1.2.3' are valid).
+     *
+     * If not provided, then the corepack version bundled with Node will be used.
+     */
+    @Parameter(property = "corepackVersion", required = false, defaultValue = "provided")
+    private String corepackVersion;
+
+    /**
+     * Server Id for download username and password
+     */
+    @Parameter(property = "serverId", defaultValue = "")
+    private String serverId;
+
+    @Parameter(property = "session", defaultValue = "${session}", readonly = true)
+    private MavenSession session;
+
+    /**
+     * Skips execution of this mojo.
+     */
+    @Parameter(property = "skip.installnodecorepack", defaultValue = "${skip.installnodecorepack}")
+    private boolean skip;
+
+    @Component(role = SettingsDecrypter.class)
+    private SettingsDecrypter decrypter;
+
+    @Override
+    protected boolean skipExecution() {
+        return this.skip;
+    }
+
+    @Override
+    public void execute(FrontendPluginFactory factory) throws InstallationException {
+        ProxyConfig proxyConfig = MojoUtils.getProxyConfig(session, decrypter);
+        String resolvedNodeDownloadRoot = getNodeDownloadRoot();
+        String resolvedCorepackDownloadRoot = getCorepackDownloadRoot();
+
+        // Setup the installers
+        NodeInstaller nodeInstaller = factory.getNodeInstaller(proxyConfig);
+        nodeInstaller.setNodeVersion(nodeVersion)
+                .setNodeDownloadRoot(resolvedNodeDownloadRoot);
+        if ("provided".equals(corepackVersion)) {
+            // This causes the node installer to copy over the whole
+            // node_modules directory including the corepack module
+            nodeInstaller.setNpmVersion("provided");
+        }
+        CorepackInstaller corepackInstaller = factory.getCorepackInstaller(proxyConfig);
+        corepackInstaller.setCorepackVersion(corepackVersion)
+                .setCorepackDownloadRoot(resolvedCorepackDownloadRoot);
+
+        // If pplicable, configure authentication details
+        Server server = MojoUtils.decryptServer(serverId, session, decrypter);
+        if (null != server) {
+            Map<String, String> httpHeaders = getHttpHeaders(server);
+            nodeInstaller
+                .setUserName(server.getUsername())
+                .setPassword(server.getPassword())
+                .setHttpHeaders(httpHeaders);
+            corepackInstaller
+                .setUserName(server.getUsername())
+                .setPassword(server.getPassword())
+                .setHttpHeaders(httpHeaders);
+        }
+
+        // Perform the installation
+        nodeInstaller.install();
+        corepackInstaller.install();
+    }
+
+    private String getNodeDownloadRoot() {
+        return nodeDownloadRoot;
+    }
+
+    private String getCorepackDownloadRoot() {
+        return corepackDownloadRoot;
+    }
+}

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndNpmMojo.java
@@ -8,6 +8,9 @@ import com.github.eirslett.maven.plugins.frontend.lib.NPMInstaller;
 import com.github.eirslett.maven.plugins.frontend.lib.NodeVersionDetector;
 import com.github.eirslett.maven.plugins.frontend.lib.NodeVersionHelper;
 import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
+
+import java.util.Map;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.lifecycle.LifecycleExecutionException;
 import org.apache.maven.plugins.annotations.Component;
@@ -139,12 +142,14 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
         Server server = MojoUtils.decryptServer(serverId, session, decrypter);
 
         if (null != server) {
+            Map<String, String> httpHeaders = getHttpHeaders(server);
             factory.getNodeInstaller(proxyConfig)
                 .setNodeVersion(validNodeVersion)
                 .setNodeDownloadRoot(nodeDownloadRoot)
                 .setNpmVersion(npmVersion)
                 .setUserName(server.getUsername())
                 .setPassword(server.getPassword())
+                .setHttpHeaders(httpHeaders)
                 .install();
             factory.getNPMInstaller(proxyConfig)
                 .setNodeVersion(validNodeVersion)
@@ -152,6 +157,7 @@ public final class InstallNodeAndNpmMojo extends AbstractFrontendMojo {
                 .setNpmDownloadRoot(npmDownloadRoot)
                 .setUserName(server.getUsername())
                 .setPassword(server.getPassword())
+                .setHttpHeaders(httpHeaders)
                 .install();
         } else {
             factory.getNodeInstaller(proxyConfig)

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndPnpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndPnpmMojo.java
@@ -8,6 +8,9 @@ import com.github.eirslett.maven.plugins.frontend.lib.NodeVersionDetector;
 import com.github.eirslett.maven.plugins.frontend.lib.NodeVersionHelper;
 import com.github.eirslett.maven.plugins.frontend.lib.PnpmInstaller;
 import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
+
+import java.util.Map;
+
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.lifecycle.LifecycleExecutionException;
 import org.apache.maven.plugins.annotations.Component;
@@ -145,17 +148,20 @@ public final class InstallNodeAndPnpmMojo extends AbstractFrontendMojo {
         Server server = MojoUtils.decryptServer(serverId, session, decrypter);
 
         if (null != server) {
+            Map<String, String> httpHeaders = getHttpHeaders(server);
             factory.getNodeInstaller(proxyConfig)
                 .setNodeVersion(validNodeVersion)
                 .setNodeDownloadRoot(resolvedNodeDownloadRoot)
                 .setUserName(server.getUsername())
                 .setPassword(server.getPassword())
+                .setHttpHeaders(httpHeaders)
                 .install();
             factory.getPnpmInstaller(proxyConfig)
                 .setPnpmVersion(pnpmVersion)
                 .setPnpmDownloadRoot(resolvedPnpmDownloadRoot)
                 .setUserName(server.getUsername())
                 .setPassword(server.getPassword())
+                .setHttpHeaders(httpHeaders)
                 .install();
         } else {
             factory.getNodeInstaller(proxyConfig)

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
@@ -15,6 +15,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.settings.Server;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
 
+import java.util.Map;
+
 import static com.github.eirslett.maven.plugins.frontend.lib.NodeInstaller.ATLASSIAN_NODE_DOWNLOAD_ROOT;
 import static com.github.eirslett.maven.plugins.frontend.lib.NodeVersionDetector.getNodeVersion;
 import static com.github.eirslett.maven.plugins.frontend.lib.NodeVersionHelper.getDownloadableVersion;
@@ -141,12 +143,14 @@ public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
         Server server = MojoUtils.decryptServer(this.serverId, this.session, this.decrypter);
 
         if (null != server) {
+            Map<String, String> httpHeaders = getHttpHeaders(server);
             factory.getNodeInstaller(proxyConfig).setNodeDownloadRoot(this.nodeDownloadRoot)
-                .setNodeVersion(validNodeVersion).setPassword(server.getPassword())
-                .setUserName(server.getUsername()).install();
+                .setNodeVersion(validNodeVersion).setUserName(server.getUsername())
+                .setPassword(server.getPassword()).setHttpHeaders(httpHeaders).install();
             factory.getYarnInstaller(proxyConfig).setYarnDownloadRoot(this.yarnDownloadRoot)
                 .setYarnVersion(this.yarnVersion).setUserName(server.getUsername())
-                .setPassword(server.getPassword()).setIsYarnBerry(isYarnYamlFilePresent).install();
+                .setPassword(server.getPassword()).setHttpHeaders(httpHeaders)
+                .setIsYarnBerry(isYarnYamlFilePresent).install();
         } else {
             factory.getNodeInstaller(proxyConfig).setNodeDownloadRoot(this.nodeDownloadRoot)
                 .setNodeVersion(validNodeVersion).install();

--- a/frontend-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/frontend-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -4,6 +4,7 @@
 		<pluginExecution>
 			<pluginExecutionFilter>
 				<goals>
+                    <goal>install-node-and-corepack</goal>
 					<goal>install-node-and-npm</goal>
 					<goal>install-node-and-pnpm</goal>
 					<goal>install-node-and-yarn</goal>
@@ -20,6 +21,7 @@
         <pluginExecution>
             <pluginExecutionFilter>
                 <goals>
+                    <goal>corepack</goal>
                     <goal>npm</goal>
                     <goal>npx</goal>
                     <goal>pnpm</goal>

--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>frontend-plugins</artifactId>
         <groupId>com.github.eirslett</groupId>
-        <version>1.15.0-atlassian-1-SNAPSHOT</version>
+        <version>1.15.1-atlassian-1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/BunExecutorConfig.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/BunExecutorConfig.java
@@ -15,6 +15,9 @@ public interface BunExecutorConfig {
 
 final class InstallBunExecutorConfig implements BunExecutorConfig {
 
+    public static final String BUN_WINDOWS = BunInstaller.INSTALL_PATH.replaceAll("/", "\\\\") + "\\bun.exe";
+    public static final String BUN_DEFAULT = BunInstaller.INSTALL_PATH + "/bun";
+
     private File nodePath;
 
     private final InstallConfig installConfig;
@@ -31,7 +34,8 @@ final class InstallBunExecutorConfig implements BunExecutorConfig {
 
     @Override
     public File getBunPath() {
-        return new File(installConfig.getInstallDirectory() + BunInstaller.INSTALL_PATH);
+        String bunExecutable = getPlatform().isWindows() ? BUN_WINDOWS : BUN_DEFAULT;
+        return new File(installConfig.getInstallDirectory() + bunExecutable);
     }
 
     @Override

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/BunInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/BunInstaller.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
+import java.util.Map;
 
 public class BunInstaller {
 
@@ -22,6 +23,8 @@ public class BunInstaller {
 
     private String bunVersion, userName, password;
 
+    private Map<String, String> httpHeaders;
+    
     private final Logger logger;
 
     private final InstallConfig config;
@@ -52,6 +55,11 @@ public class BunInstaller {
         return this;
     }
 
+    public BunInstaller setHttpHeaders(Map<String, String> httpHeaders) {
+        this.httpHeaders = httpHeaders;
+        return this;
+    }
+    
     public void install() throws InstallationException {
         // use static lock object for a synchronized block
         synchronized (LOCK) {
@@ -59,11 +67,7 @@ public class BunInstaller {
                 if (!this.bunVersion.startsWith("v")) {
                     this.logger.warn("Bun version does not start with naming convention 'v'.");
                 }
-                if (this.config.getPlatform().isWindows()) {
-                    throw new InstallationException("Unable to install bun on windows!");
-                } else {
-                    installBunDefault();
-                }
+                installBunDefault();
             }
         }
     }
@@ -105,15 +109,16 @@ public class BunInstaller {
 
             File archive = this.config.getCacheResolver().resolve(cacheDescriptor);
 
-            downloadFileIfMissing(downloadUrl, archive, this.userName, this.password);
+            downloadFileIfMissing(downloadUrl, archive, this.userName, this.password, this.httpHeaders);
 
             File installDirectory = getInstallDirectory();
 
             // We need to delete the existing bun directory first so we clean out any old files, and
             // so we can rename the package directory below.
+            File bunExtractDirectory = new File(installDirectory, createBunTargetArchitecturePath());
             try {
-                if (installDirectory.isDirectory()) {
-                    FileUtils.deleteDirectory(installDirectory);
+                if (bunExtractDirectory.isDirectory()) {
+                    FileUtils.deleteDirectory(bunExtractDirectory);
                 }
             } catch (IOException e) {
                 logger.warn("Failed to delete existing Bun installation.");
@@ -127,20 +132,24 @@ public class BunInstaller {
                             + "Please try the build again.", archive.getPath());
                     archive.delete();
                 }
-
                 throw e;
             }
 
             // Search for the bun binary
+            String bunExecutable = this.config.getPlatform().isWindows()  ? "bun.exe" : "bun";
             File bunBinary =
-                    new File(getInstallDirectory(), File.separator + createBunTargetArchitecturePath() + File.separator + "bun");
+                    new File(installDirectory, File.separator + createBunTargetArchitecturePath() + File.separator + bunExecutable);
             if (!bunBinary.exists()) {
                 throw new FileNotFoundException(
                         "Could not find the downloaded bun binary in " + bunBinary);
             } else {
-                File destinationDirectory = getInstallDirectory();
+                File destinationDirectory = new File(getInstallDirectory(), BunInstaller.INSTALL_PATH);
+                if (!destinationDirectory.exists()) {
+                    this.logger.info("Creating destination directory {}", destinationDirectory);
+                    destinationDirectory.mkdirs();
+                }
 
-                File destination = new File(destinationDirectory, "bun");
+                File destination = new File(destinationDirectory, bunExecutable);
                 this.logger.info("Copying bun binary from {} to {}", bunBinary, destination);
                 if (destination.exists() && !destination.delete()) {
                     throw new InstallationException("Could not install Bun: Was not allowed to delete " + destination);
@@ -156,6 +165,7 @@ public class BunInstaller {
                     throw new InstallationException(
                             "Could not install Bun: Was not allowed to make " + destination + " executable.");
                 }
+                FileUtils.deleteDirectory(bunExtractDirectory);
 
                 this.logger.info("Installed bun locally.");
             }
@@ -180,7 +190,7 @@ public class BunInstaller {
     private String createBunTargetArchitecturePath() {
         OS os = OS.guess();
         Architecture architecture = Architecture.guess();
-        String destOs = os.equals(OS.Linux) ? "linux" : os.equals(OS.Mac) ? "darwin" : null;
+        String destOs = os.equals(OS.Linux) ? "linux" : os.equals(OS.Mac) ? "darwin" : os.equals(OS.Windows) ? "windows" : null;
         String destArc = architecture.equals(Architecture.x64) ? "x64" : architecture.equals(
                 Architecture.arm64) ? "aarch64" : null;
         return String.format("%s-%s-%s", INSTALL_PATH, destOs, destArc);
@@ -200,16 +210,16 @@ public class BunInstaller {
         this.archiveExtractor.extract(archive.getPath(), destinationDirectory.getPath());
     }
 
-    private void downloadFileIfMissing(String downloadUrl, File destination, String userName, String password)
+    private void downloadFileIfMissing(String downloadUrl, File destination, String userName, String password, Map<String, String> httpHeaders)
             throws DownloadException {
         if (!destination.exists()) {
-            downloadFile(downloadUrl, destination, userName, password);
+            downloadFile(downloadUrl, destination, userName, password, httpHeaders);
         }
     }
 
-    private void downloadFile(String downloadUrl, File destination, String userName, String password)
+    private void downloadFile(String downloadUrl, File destination, String userName, String password, Map<String, String> httpHeaders)
             throws DownloadException {
         this.logger.info("Downloading {} to {}", downloadUrl, destination);
-        this.fileDownloader.download(downloadUrl, destination.getPath(), userName, password);
+        this.fileDownloader.download(downloadUrl, destination.getPath(), userName, password, httpHeaders);
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/CorepackInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/CorepackInstaller.java
@@ -15,6 +15,8 @@ public class CorepackInstaller {
 
     private static final String VERSION = "version";
 
+    public static final String ATLASSIAN_COREPACK_DOWNLOAD_ROOT = "https://packages.atlassian.com/artifactory/api/npm/npm-remote/corepack/-/";
+
     public static final String DEFAULT_COREPACK_DOWNLOAD_ROOT = "https://registry.npmjs.org/corepack/-/";
 
     private static final Object LOCK = new Object();
@@ -22,7 +24,7 @@ public class CorepackInstaller {
     private String corepackVersion, corepackDownloadRoot, userName, password;
 
     private Map<String, String> httpHeaders;
-    
+
     private final Logger logger;
 
     private final InstallConfig config;

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/CorepackRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/CorepackRunner.java
@@ -1,0 +1,15 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+public interface CorepackRunner extends NodeTaskRunner {}
+
+final class DefaultCorepackRunner extends NodeTaskExecutor implements CorepackRunner {
+    static final String TASK_NAME = "corepack";
+
+    public DefaultCorepackRunner(NodeExecutorConfig config) {
+        super(config, TASK_NAME, config.getCorepackPath().getAbsolutePath());
+
+        if (!config.getCorepackPath().exists()) {
+            setTaskLocation(config.getCorepackPath().getAbsolutePath());
+        }
+    }
+}

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FileDownloader.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FileDownloader.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.FileUtils;
@@ -30,7 +31,7 @@ import org.slf4j.LoggerFactory;
 import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig.Proxy;
 
 interface FileDownloader {
-    void download(String downloadUrl, String destination, String userName, String password) throws DownloadException;
+    void download(String downloadUrl, String destination, String userName, String password, Map<String, String> header) throws DownloadException;
 }
 
 final class DefaultFileDownloader implements FileDownloader {
@@ -43,7 +44,7 @@ final class DefaultFileDownloader implements FileDownloader {
     }
 
     @Override
-    public void download(String downloadUrl, String destination, String userName, String password) throws DownloadException {
+    public void download(String downloadUrl, String destination, String userName, String password, Map<String, String> httpHeaders) throws DownloadException {
         // force tls to 1.2 since github removed weak cryptographic standards
         // https://blog.github.com/2018-02-02-weak-cryptographic-standards-removal-notice/
         System.setProperty("https.protocols", "TLSv1.2");
@@ -55,7 +56,7 @@ final class DefaultFileDownloader implements FileDownloader {
                 FileUtils.copyFile(new File(downloadURI), new File(destination));
             }
             else {
-                CloseableHttpResponse response = execute(fixedDownloadUrl, userName, password);
+                CloseableHttpResponse response = execute(fixedDownloadUrl, userName, password, httpHeaders);
                 int statusCode = response.getStatusLine().getStatusCode();
                 if(statusCode != 200){
                     throw new DownloadException("Got error code "+ statusCode +" from the server.");
@@ -70,7 +71,7 @@ final class DefaultFileDownloader implements FileDownloader {
         }
     }
 
-    private CloseableHttpResponse execute(String requestUrl, String userName, String password) throws IOException {
+    private CloseableHttpResponse execute(String requestUrl, String userName, String password, Map<String, String> httpHeaders) throws IOException {
         final HttpGet request = new HttpGet(requestUrl);
         final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
 
@@ -90,6 +91,13 @@ final class DefaultFileDownloader implements FileDownloader {
             }
         } else {
             LOGGER.info("No proxy was configured, downloading directly");
+        }
+        
+        if (httpHeaders != null) {
+            for (Map.Entry<String, String> header : httpHeaders.entrySet()) {
+                LOGGER.info("Using HTTP-Header (" + header.getKey() + ") from settings.xml");
+                request.addHeader(header.getKey(), header.getValue());
+            }
         }
 
         if (StringUtils.isNotEmpty(userName) && StringUtils.isNotEmpty(password)) {

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/FrontendPluginFactory.java
@@ -32,6 +32,10 @@ public final class FrontendPluginFactory {
         return new NPMInstaller(getInstallConfig(), new DefaultArchiveExtractor(), new DefaultFileDownloader(proxy));
     }
 
+    public CorepackInstaller getCorepackInstaller(ProxyConfig proxy) {
+        return new CorepackInstaller(getInstallConfig(), new DefaultArchiveExtractor(), new DefaultFileDownloader(proxy));
+    }
+
     public PnpmInstaller getPnpmInstaller(ProxyConfig proxy) {
         return new PnpmInstaller(getInstallConfig(), new DefaultArchiveExtractor(), new DefaultFileDownloader(proxy));
     }
@@ -54,6 +58,10 @@ public final class FrontendPluginFactory {
 
     public NpmRunner getNpmRunner(ProxyConfig proxy, String npmRegistryURL) {
         return new DefaultNpmRunner(getExecutorConfig(), proxy, npmRegistryURL);
+    }
+
+    public CorepackRunner getCorepackRunner() {
+        return new DefaultCorepackRunner(getExecutorConfig());
     }
 
     public PnpmRunner getPnpmRunner(ProxyConfig proxyConfig, String npmRegistryUrl) {

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NPMInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NPMInstaller.java
@@ -6,6 +6,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +25,8 @@ public class NPMInstaller {
 
     private String nodeVersion, npmVersion, npmDownloadRoot, userName, password;
 
+    private Map<String, String> httpHeaders;
+    
     private final Logger logger;
 
     private final InstallConfig config;
@@ -60,6 +64,11 @@ public class NPMInstaller {
 
     public NPMInstaller setPassword(String password) {
         this.password = password;
+        return this;
+    }
+
+    public NPMInstaller setHttpHeaders(Map<String, String> httpHeaders) {
+        this.httpHeaders = httpHeaders;
         return this;
     }
 
@@ -125,7 +134,7 @@ public class NPMInstaller {
 
             File archive = this.config.getCacheResolver().resolve(cacheDescriptor);
 
-            downloadFileIfMissing(downloadUrl, archive, this.userName, this.password);
+            downloadFileIfMissing(downloadUrl, archive, this.userName, this.password, this.httpHeaders);
 
             File installDirectory = getNodeInstallDirectory();
             File nodeModulesDirectory = new File(installDirectory, "node_modules");
@@ -221,16 +230,16 @@ public class NPMInstaller {
         this.archiveExtractor.extract(archive.getPath(), destinationDirectory.getPath());
     }
 
-    private void downloadFileIfMissing(String downloadUrl, File destination, String userName, String password)
+    private void downloadFileIfMissing(String downloadUrl, File destination, String userName, String password, Map<String, String> httpHeaders)
         throws DownloadException {
         if (!destination.exists()) {
-            downloadFile(downloadUrl, destination, userName, password);
+            downloadFile(downloadUrl, destination, userName, password, httpHeaders);
         }
     }
 
-    private void downloadFile(String downloadUrl, File destination, String userName, String password)
+    private void downloadFile(String downloadUrl, File destination, String userName, String password, Map<String, String> httpHeaders)
         throws DownloadException {
         this.logger.info("Downloading {} to {}", downloadUrl, destination);
-        this.fileDownloader.download(downloadUrl, destination.getPath(), userName, password);
+        this.fileDownloader.download(downloadUrl, destination.getPath(), userName, password, httpHeaders);
     }
 }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutorConfig.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutorConfig.java
@@ -7,6 +7,7 @@ public interface NodeExecutorConfig {
   File getNpmPath();
   File getPnpmPath();
   File getPnpmCjsPath();
+  File getCorepackPath();
 
   File getNpxPath();
   File getInstallDirectory();
@@ -21,6 +22,7 @@ final class InstallNodeExecutorConfig implements NodeExecutorConfig {
   private static final String NPM = NodeInstaller.INSTALL_PATH + "/node_modules/npm/bin/npm-cli.js";
   private static final String PNPM = NodeInstaller.INSTALL_PATH + "/node_modules/pnpm/bin/pnpm.js";
   private static final String PNPM_CJS = NodeInstaller.INSTALL_PATH + "/node_modules/pnpm/bin/pnpm.cjs";
+  private static final String COREPACK = NodeInstaller.INSTALL_PATH + "/node_modules/corepack/dist/corepack.js";
   private static final String NPX = NodeInstaller.INSTALL_PATH + "/node_modules/npm/bin/npx-cli.js";
 
   private final InstallConfig installConfig;
@@ -49,6 +51,11 @@ final class InstallNodeExecutorConfig implements NodeExecutorConfig {
   @Override
   public File getPnpmCjsPath() {
     return new File(installConfig.getInstallDirectory() + Utils.normalize(PNPM_CJS));
+  }
+
+  @Override
+  public File getCorepackPath() {
+    return new File(installConfig.getInstallDirectory() + Utils.normalize(COREPACK));
   }
 
   @Override

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnInstaller.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnInstaller.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -25,6 +26,8 @@ public class YarnInstaller {
     private static final String YARN_ROOT_DIRECTORY = "dist";
 
     private String yarnVersion, yarnDownloadRoot, userName, password;
+    
+    private Map<String, String> httpHeaders;
 
     private boolean isYarnBerry;
 
@@ -65,6 +68,11 @@ public class YarnInstaller {
 
     public YarnInstaller setPassword(String password) {
         this.password = password;
+        return this;
+    }
+
+    public YarnInstaller setHttpHeaders(Map<String, String> httpHeaders) {
+        this.httpHeaders = httpHeaders;
         return this;
     }
 
@@ -124,7 +132,7 @@ public class YarnInstaller {
 
             File archive = config.getCacheResolver().resolve(cacheDescriptor);
 
-            downloadFileIfMissing(downloadUrl, archive, userName, password);
+            downloadFileIfMissing(downloadUrl, archive, userName, password, httpHeaders);
 
             File installDirectory = getInstallDirectory();
 
@@ -196,16 +204,16 @@ public class YarnInstaller {
         }
     }
 
-    private void downloadFileIfMissing(String downloadUrl, File destination, String userName, String password)
+    private void downloadFileIfMissing(String downloadUrl, File destination, String userName, String password, Map<String, String> httpHeaders)
         throws DownloadException {
         if (!destination.exists()) {
-            downloadFile(downloadUrl, destination, userName, password);
+            downloadFile(downloadUrl, destination, userName, password, httpHeaders);
         }
     }
 
-    private void downloadFile(String downloadUrl, File destination, String userName, String password)
+    private void downloadFile(String downloadUrl, File destination, String userName, String password, Map<String, String> httpHeaders)
         throws DownloadException {
         logger.info("Downloading {} to {}", downloadUrl, destination);
-        fileDownloader.download(downloadUrl, destination.getPath(), userName, password);
+        fileDownloader.download(downloadUrl, destination.getPath(), userName, password, httpHeaders);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.eirslett</groupId>
     <artifactId>frontend-plugins</artifactId>
-    <version>1.15.0-atlassian-1-SNAPSHOT</version>
+    <version>1.15.1-atlassian-1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/settings-github.xml
+++ b/settings-github.xml
@@ -2,8 +2,8 @@
     <servers>
         <server>
             <id>ossrh</id>
-            <username>${env.OSSRH_JIRA_USERNAME}</username>
-            <password>${env.OSSRH_JIRA_PASSWORD}</password>
+            <username>${env.OSSRH_TOKEN_USERNAME}</username>
+            <password>${env.OSSRH_TOKEN_PASSWORD}</password>
         </server>
     </servers>
 </settings>


### PR DESCRIPTION
Syncing to the latest version which has HTTP header support (we won't use it) and Corepack support (we will use this for Yarn v4 support).

Keeping it the same as the released version upstream which makes reporting and debugging issues easier.

QA demod with @rafalsatl 