### PR TITLE
DCA11Y-1274 - Incremental compilation updates & minor fixes

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - [DCA11Y-1274]: Null arguments for mojos would fail the build
 - [DCA11Y-1274]: Fix incremental with Yarn berry by fixing runtime detection
+- [DCA11Y-1274]: Corepack Mojo incremental works
 
 ### Added
 

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - [DCA11Y-1274]: Null arguments for mojos would fail the build
 - [DCA11Y-1274]: Fix incremental with Yarn berry by fixing runtime detection
 - [DCA11Y-1274]: Corepack Mojo incremental works
+- [DCA11Y-1274]: Fix updating of digest versions without clean install
 
 ### Added
 

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - [DCA11Y-1274]: Fix incremental with Yarn berry by fixing runtime detection
 - [DCA11Y-1274]: Corepack Mojo incremental works
 - [DCA11Y-1274]: Fix updating of digest versions without clean install
+- [DCA11Y-1274]: Download dev metrics now correctly report PAC
+- [DCA11Y-1145]: Fixed the legacy "downloadRoot" argument for PNPM & NPM installation
 
 ### Added
 

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - [DCA11Y-1274]: Null arguments for mojos would fail the build
+- [DCA11Y-1274]: Fix incremental with Yarn berry by fixing runtime detection
 
 ### Added
 

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [1.15.1-atlassian-3]  - 2024-11-29
 
 ### Fixed
 
@@ -20,13 +20,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - [DCA11Y-1274]: ".flattened-pom.xml" & ".git" to the excluded filenames list after finding it in Jira
 - [DCA11Y-1274]: Log message indicating how much time is saved
 
-## [1.15.1-atlassian-2]
+## [1.15.1-atlassian-2] - 2024-11-26
 
 ### Added
 
 - [DCA11Y-1274]: Incremental builds for Yarn, Corepack and NPM goals 
 
-## [1.15.1-atlassian-1]
+## [1.15.1-atlassian-1] - 2024-11-25
 
 - [DCA11Y-1145]: Automatic version detection of the Node version from `.tool-versions`, `.node-version`, and `.nvmrc` files
 - [DCA11Y-1145]: The configuration property `nodeVersionFile` to specify a file that can be read in `install-node-and-npm`, `install-node-and-pnpm`, and `install-node-and-yarn`
@@ -35,6 +35,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - [DCA11Y-1145]: Now tolerant of `v` missing or present at the start of a Node version
 
+
+
 [DCA11Y-1274]: https://hello.jira.atlassian.cloud/browse/DCA11Y-1274
 [DCA11Y-1145]: https://hello.jira.atlassian.cloud/browse/DCA11Y-1145
-[unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.15.1-atlassian-2...HEAD
+
+[unreleased]: https://github.com/atlassian-forks/frontend-maven-plugin/compare/frontend-plugins-1.15.1-atlassian-3...HEAD
+[1.15.1-atlassian-3]: https://github.com/atlassian-forks/frontend-maven-plugin/compare/frontend-plugins-1.15.1-atlassian-2...frontend-plugins-1.15.1-atlassian-3
+[1.15.1-atlassian-2]: https://github.com/atlassian-forks/frontend-maven-plugin/compare/frontend-plugins-1.15.1-atlassian-1...frontend-plugins-1.15.1-atlassian-2
+[1.15.1-atlassian-1]: https://github.com/atlassian-forks/frontend-maven-plugin/compare/frontend-plugins-1.15.1-atlassian-1-16519678...frontend-plugins-1.15.1-atlassian-1
+[1.15.1-atlassian-1-16519678]: https://github.com/atlassian-forks/frontend-maven-plugin/compare/frontend-plugins-1.15.1...frontend-plugins-1.15.1-atlassian-1-16519678

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- [DCA11Y-1274]: Null arguments for mojos would fail the build
+
 ## [1.15.1-atlassian-2]
 
 ### Added

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- [DCA11Y-1274]: ".flattened-pom.xml" to the excluded filenames list after finding it in Jira
+- [DCA11Y-1274]: ".flattened-pom.xml" & ".git" to the excluded filenames list after finding it in Jira
 - [DCA11Y-1274]: Log message indicating how much time is saved
 
 ## [1.15.1-atlassian-2]

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - [DCA11Y-1274]: ".flattened-pom.xml" to the excluded filenames list after finding it in Jira
+- [DCA11Y-1274]: Log message indicating how much time is saved
 
 ## [1.15.1-atlassian-2]
 

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - [DCA11Y-1274]: Null arguments for mojos would fail the build
 
+### Added
+
+- [DCA11Y-1274]: ".flattened-pom.xml" to the excluded filenames list after finding it in Jira
+
 ## [1.15.1-atlassian-2]
 
 ### Added

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/CorepackMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/CorepackMojo.java
@@ -51,7 +51,7 @@ public final class CorepackMojo extends AbstractFrontendMojo {
      * to the defaults in {@link IncrementalMojoHelper}. Whole directories will be
      * excluded.
      */
-    @Parameter(property = "excludedFilenames", required = false, defaultValue = "node_modules,lcov-report,coverage,screenshots,build,dist,target,.idea,.history,tmp,.settings,.vscode,dependency-reduced-pom.xml,.flattened-pom.xml")
+    @Parameter(property = "excludedFilenames", required = false, defaultValue = "node_modules,lcov-report,coverage,screenshots,build,dist,target,.idea,.history,tmp,.settings,.vscode,.git,dependency-reduced-pom.xml,.flattened-pom.xml")
     private Set<String> excludedFilenames;
 
     @Component(role = SettingsDecrypter.class)

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/CorepackMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/CorepackMojo.java
@@ -72,11 +72,11 @@ public final class CorepackMojo extends AbstractFrontendMojo {
     public synchronized void execute(FrontendPluginFactory factory) throws Exception {
         CorepackRunner runner = factory.getCorepackRunner();
 
-        IncrementalMojoHelper incrementalHelper = new IncrementalMojoHelper(frontendIncremental, getTargetDir(), workingDirectory, triggerFiles, excludedFilenames);
         ExecutionCoordinates coordinates = new ExecutionCoordinates(execution.getGoal(), execution.getExecutionId(), execution.getLifecyclePhase());
+        IncrementalMojoHelper incrementalHelper = new IncrementalMojoHelper(frontendIncremental, coordinates, getTargetDir(), workingDirectory, triggerFiles, excludedFilenames);
 
         boolean incrementalEnabled = incrementalHelper.incrementalEnabled();
-        boolean isIncremental = incrementalEnabled && incrementalHelper.canBeSkipped(arguments, coordinates, runner.getRuntime(), environmentVariables, project.getArtifactId(), getFrontendMavenPluginVersion());
+        boolean isIncremental = incrementalEnabled && incrementalHelper.canBeSkipped(arguments, runner.getRuntime(), environmentVariables, project.getArtifactId(), getFrontendMavenPluginVersion());
 
         incrementExecutionCount(project.getArtifactId(), arguments, COREPACK, getFrontendMavenPluginVersion(), incrementalEnabled, isIncremental, () -> {
             if (isIncremental) {

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/CorepackMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/CorepackMojo.java
@@ -83,6 +83,8 @@ public final class CorepackMojo extends AbstractFrontendMojo {
                 getLog().info("Skipping corepack execution as no modified files in " + workingDirectory);
             } else {
                 runner.execute(arguments, environmentVariables);
+
+                incrementalHelper.acceptIncrementalBuildDigest();
             }
         });
     }

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/CorepackMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/CorepackMojo.java
@@ -51,7 +51,7 @@ public final class CorepackMojo extends AbstractFrontendMojo {
      * to the defaults in {@link IncrementalMojoHelper}. Whole directories will be
      * excluded.
      */
-    @Parameter(property = "excludedFilenames", required = false, defaultValue = "node_modules,lcov-report,coverage,screenshots,build,dist,target,.idea,.history,tmp,.settings,.vscode,dependency-reduced-pom.xml")
+    @Parameter(property = "excludedFilenames", required = false, defaultValue = "node_modules,lcov-report,coverage,screenshots,build,dist,target,.idea,.history,tmp,.settings,.vscode,dependency-reduced-pom.xml,.flattened-pom.xml")
     private Set<String> excludedFilenames;
 
     @Component(role = SettingsDecrypter.class)

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/InstallNodeAndYarnMojo.java
@@ -148,7 +148,7 @@ public final class InstallNodeAndYarnMojo extends AbstractFrontendMojo {
                     pacAttemptFailed = true;
                     getLog().warn("Oh no couldn't use the internal mirrors! Falling back to upstream mirrors");
                     getLog().debug("Using internal mirrors failed because: ", exception);
-                } finally {
+
                     nodeDownloadRoot = userSetNodeDownloadRoot;
                     yarnDownloadRoot = userSetYarnDownloadRoot;
                     serverId = null;

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -61,7 +61,7 @@ public final class NpmMojo extends AbstractFrontendMojo {
      * to the defaults in {@link IncrementalMojoHelper}. Whole directories will be
      * excluded.
      */
-    @Parameter(property = "excludedFilenames", defaultValue = "node_modules,lcov-report,coverage,screenshots,build,dist,target,.idea,.history,tmp,.settings,.vscode,dependency-reduced-pom.xml,.flattened-pom.xml", required = false)
+    @Parameter(property = "excludedFilenames", defaultValue = "node_modules,lcov-report,coverage,screenshots,build,dist,target,.idea,.history,tmp,.settings,.vscode,.git,dependency-reduced-pom.xml,.flattened-pom.xml", required = false)
     private Set<String> excludedFilenames;
 
     @Component

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -85,11 +85,11 @@ public final class NpmMojo extends AbstractFrontendMojo {
     public synchronized void execute(FrontendPluginFactory factory) throws Exception {
         NpmRunner runner = factory.getNpmRunner(getProxyConfig(), getRegistryUrl());
 
-        IncrementalMojoHelper incrementalHelper = new IncrementalMojoHelper(frontendIncremental, getTargetDir(), workingDirectory, triggerFiles, excludedFilenames);
         ExecutionCoordinates coordinates = new ExecutionCoordinates(execution.getGoal(), execution.getExecutionId(), execution.getLifecyclePhase());
+        IncrementalMojoHelper incrementalHelper = new IncrementalMojoHelper(frontendIncremental, coordinates, getTargetDir(), workingDirectory, triggerFiles, excludedFilenames);
 
         boolean incrementalEnabled = incrementalHelper.incrementalEnabled();
-        boolean isIncremental = incrementalEnabled && incrementalHelper.canBeSkipped(arguments, coordinates, runner.getRuntime(), environmentVariables, project.getArtifactId(), getFrontendMavenPluginVersion());
+        boolean isIncremental = incrementalEnabled && incrementalHelper.canBeSkipped(arguments, runner.getRuntime(), environmentVariables, project.getArtifactId(), getFrontendMavenPluginVersion());
 
         incrementExecutionCount(project.getArtifactId(), arguments, NPM, getFrontendMavenPluginVersion(), incrementalEnabled, isIncremental, () -> {
             if (isIncremental) {

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/NpmMojo.java
@@ -61,7 +61,7 @@ public final class NpmMojo extends AbstractFrontendMojo {
      * to the defaults in {@link IncrementalMojoHelper}. Whole directories will be
      * excluded.
      */
-    @Parameter(property = "excludedFilenames", defaultValue = "node_modules,lcov-report,coverage,screenshots,build,dist,target,.idea,.history,tmp,.settings,.vscode,dependency-reduced-pom.xml", required = false)
+    @Parameter(property = "excludedFilenames", defaultValue = "node_modules,lcov-report,coverage,screenshots,build,dist,target,.idea,.history,tmp,.settings,.vscode,dependency-reduced-pom.xml,.flattened-pom.xml", required = false)
     private Set<String> excludedFilenames;
 
     @Component

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/YarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/YarnMojo.java
@@ -63,7 +63,7 @@ public final class YarnMojo extends AbstractFrontendMojo {
      * to the defaults in {@link IncrementalMojoHelper}. Whole directories will be
      * excluded.
      */
-    @Parameter(property = "excludedFilenames", required = false, defaultValue = "node_modules,lcov-report,coverage,screenshots,build,dist,target,.idea,.history,tmp,.settings,.vscode,dependency-reduced-pom.xml,.flattened-pom.xml")
+    @Parameter(property = "excludedFilenames", required = false, defaultValue = "node_modules,lcov-report,coverage,screenshots,build,dist,target,.idea,.history,tmp,.settings,.vscode,.git,dependency-reduced-pom.xml,.flattened-pom.xml")
     private Set<String> excludedFilenames;
 
     @Component

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/YarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/YarnMojo.java
@@ -63,7 +63,7 @@ public final class YarnMojo extends AbstractFrontendMojo {
      * to the defaults in {@link IncrementalMojoHelper}. Whole directories will be
      * excluded.
      */
-    @Parameter(property = "excludedFilenames", required = false, defaultValue = "node_modules,lcov-report,coverage,screenshots,build,dist,target,.idea,.history,tmp,.settings,.vscode,dependency-reduced-pom.xml")
+    @Parameter(property = "excludedFilenames", required = false, defaultValue = "node_modules,lcov-report,coverage,screenshots,build,dist,target,.idea,.history,tmp,.settings,.vscode,dependency-reduced-pom.xml,.flattened-pom.xml")
     private Set<String> excludedFilenames;
 
     @Component

--- a/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/YarnMojo.java
+++ b/frontend-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/mojo/YarnMojo.java
@@ -88,11 +88,11 @@ public final class YarnMojo extends AbstractFrontendMojo {
         boolean isYarnBerry = isYarnrcYamlFilePresent(this.session, this.workingDirectory);
         YarnRunner runner = factory.getYarnRunner(getProxyConfig(), getRegistryUrl(), isYarnBerry);
 
-        IncrementalMojoHelper incrementalHelper = new IncrementalMojoHelper(frontendIncremental, getTargetDir(), workingDirectory, triggerFiles, excludedFilenames);
         ExecutionCoordinates coordinates = new ExecutionCoordinates(execution.getGoal(), execution.getExecutionId(), execution.getLifecyclePhase());
+        IncrementalMojoHelper incrementalHelper = new IncrementalMojoHelper(frontendIncremental, coordinates, getTargetDir(), workingDirectory, triggerFiles, excludedFilenames);
 
         boolean incrementalEnabled = incrementalHelper.incrementalEnabled();
-        boolean isIncremental = incrementalEnabled && incrementalHelper.canBeSkipped(arguments, coordinates, runner.getRuntime(), environmentVariables, project.getArtifactId(), getFrontendMavenPluginVersion());
+        boolean isIncremental = incrementalEnabled && incrementalHelper.canBeSkipped(arguments, runner.getRuntime(), environmentVariables, project.getArtifactId(), getFrontendMavenPluginVersion());
 
         incrementExecutionCount(project.getArtifactId(), arguments, YARN, getFrontendMavenPluginVersion(), incrementalEnabled, isIncremental, () -> {
             if (isIncremental) {

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/AtlassianDevMetricsReporter.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/AtlassianDevMetricsReporter.java
@@ -32,6 +32,7 @@ import static java.lang.Runtime.getRuntime;
 import static java.lang.System.getProperty;
 import static java.lang.System.getenv;
 import static java.time.Instant.now;
+import static java.util.Objects.isNull;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
@@ -262,6 +263,10 @@ public class AtlassianDevMetricsReporter  {
      * perfect
      */
     static String getScriptFromArguments(String arguments) {
+        if (isNull(arguments)) {
+            arguments = "";
+        }
+
         if (arguments.contains("test") || arguments.contains("check") || arguments.contains("visreg") || arguments.contains("jest") || arguments.contains("storybook")) {
             return "test";
         }

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/IncrementalBuildExecutionDigest.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/IncrementalBuildExecutionDigest.java
@@ -26,7 +26,7 @@ public class IncrementalBuildExecutionDigest {
     /**
      * This should be incremented as soon as the digest schema or semantics change
      */
-    public static final Long CURRENT_DIGEST_VERSION = 1L;
+    public static final Long CURRENT_DIGEST_VERSION = 2L;
 
     private static final String SERIALIZATION_CHARSET = UTF_8.toString();
     /**
@@ -83,6 +83,7 @@ public class IncrementalBuildExecutionDigest {
         public Map<String, String> environmentVariables;
         public Set<File> files;
         public Runtime runtime;
+        public Long millisecondsSaved = 0L;
 
         public Execution() {
             // for Jackson
@@ -170,12 +171,12 @@ public class IncrementalBuildExecutionDigest {
         public boolean equals(Object o) {
             if (!(o instanceof Execution)) return false;
             Execution execution = (Execution) o;
-            return Objects.equals(files, execution.files) && Objects.equals(environmentVariables, execution.environmentVariables) && Objects.equals(arguments, execution.arguments) && Objects.equals(runtime, execution.runtime);
+            return Objects.equals(files, execution.files) && Objects.equals(environmentVariables, execution.environmentVariables) && Objects.equals(arguments, execution.arguments) && Objects.equals(runtime, execution.runtime) && Objects.equals(millisecondsSaved, execution.millisecondsSaved);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(files, environmentVariables, arguments, runtime);
+            return Objects.hash(files, environmentVariables, arguments, runtime, millisecondsSaved);
         }
     }
 

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/IncrementalMojoHelper.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/IncrementalMojoHelper.java
@@ -149,6 +149,7 @@ public class IncrementalMojoHelper {
                 startTimeForSaveTimeUpdate = Optional.of(now());
             }
 
+            digest.digestVersion = CURRENT_DIGEST_VERSION;
             digest.executions.put(coordinates, thisExecution);
 
             return canSkipExecution;

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnRunner.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnRunner.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
@@ -59,6 +60,16 @@ final class DefaultYarnRunner extends YarnTaskExecutor implements YarnRunner {
     }
 
     /**
+     * <p>
+     * Running {@code yarn node --version} in yarn classic gives us an output like this:
+     * <pre>
+     * yarn node v1.22.22
+     * v20.10.0
+     * Done in 0.02s.
+     * </pre>
+     * while yarn berry will give us just the output
+     * </p>
+     * <p>
      * Running {@code yarn versions} gives an output like this:
      * <pre>
      * yarn versions v1.22.22
@@ -74,9 +85,23 @@ final class DefaultYarnRunner extends YarnTaskExecutor implements YarnRunner {
      * The first line is repeated and the last one will cause an unnecessary diff. Running
      * with {@code --silent culls the first and last lines}, but this isn't available on all yarn
      * classic versions, e.g. 1.22.17
+     * </p>
      */
     @Override
     public Optional<Runtime> getRuntime() {
+        // Why not call config.isYarnBerry() ?? Well it can lie since it's not using what's
+        // on the path..... it's just looking at files
+        try {
+            String output = new YarnExecutor(config, asList("node", "--version"), emptyMap())
+                    .executeAndGetResult(logger);
+            if (output.startsWith("yarn node")) {
+                output = output.substring(output.indexOf("\n"), output.lastIndexOf("\n")).trim();
+            }
+            return Optional.of(new Runtime("node", output));
+        } catch (Exception exception) {
+            logger.debug("Failed to get the Node version from yarn, will fallback and hope it's yarn classic. Failed because: ", exception);
+        }
+
         try {
             String rawVersions = new YarnExecutor(config, singletonList("versions"), emptyMap())
                     .executeAndGetResult(logger);
@@ -88,7 +113,7 @@ final class DefaultYarnRunner extends YarnTaskExecutor implements YarnRunner {
             // information that's more ideal to track
             return Optional.of(new Runtime("yarn", desiredVersions));
         } catch (Exception exception) {
-            logger.debug("Failed to get the runtime versions from yarn, because: ", exception);
+            logger.debug("Failed to get the Node version from yarn, even after assuming it's yarn classic. Failed because: ", exception);
             return empty();
         }
     }


### PR DESCRIPTION
Best to look commit by commit.

- DCA11Y-1274: Update CHANGELOG.md ahead of release
- DCA11Y-1274: Ignore .git folders
- DCA11Y-1274: Fix download dev metrics to correctly report PAC
- DCA11Y-1274: Fix digest version invalidation
- DCA11Y-1274: Fix incremental compilation in CorepackMojo
- DCA11Y-1274: Log time saved
- DCA11Y-1274: Fix incremental compilation for Yarn berry
- DCA11Y-1274: Add incremental build support to CorepackMojo
- DCA11Y-1274: Fix "null" arguments for mojos would fail the build

Discovered while testing adoption in the products.