### PR TITLE
DCA11Y-1733: Stream the file to be hashed

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - [DCA11Y-1504]: Local mise configuration files have now precedence over global ones
+- [DCA11Y-1733]: Incremental compilation causing memory pressure from reading in entire files
 
 ## [1.15.1-atlassian-3]  - 2024-11-29
 

--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -82,7 +82,7 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>33.1.0-jre</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>

--- a/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/IncrementalBuildExecutionDigest.java
+++ b/frontend-plugin-core/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/IncrementalBuildExecutionDigest.java
@@ -98,14 +98,14 @@ public class IncrementalBuildExecutionDigest {
 
         public static class File {
             public String filename;
-            public Integer byteLength;
+            public Long byteLength;
             public String hash;
 
             public File() {
                 // for Jackson
             }
 
-            public File(String filename, Integer byteLength, String hash) {
+            public File(String filename, Long byteLength, String hash) {
                 this.filename = filename;
                 this.byteLength = byteLength;
                 this.hash = hash;

--- a/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/IncrementalBuildExecutionDigestTest.java
+++ b/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/IncrementalBuildExecutionDigestTest.java
@@ -34,7 +34,7 @@ public class IncrementalBuildExecutionDigestTest {
                         new Execution(
                                 "test-arguments",
                                 Collections.singletonMap("NODE_ENV", "test"),
-                                new HashSet<>(singletonList(new File("test-file.js", 12345, "abc123"))),
+                                new HashSet<>(singletonList(new File("test-file.js", 12345L, "abc123"))),
                                 new Runtime("node", "{\n" +
                                         "  '@atlassian/solicitorio': '3.4.0',\n" +
                                         "  npm: '8.15.0',\n" +

--- a/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/IncrementalMojoHelperTest.java
+++ b/frontend-plugin-core/src/test/java/com/github/eirslett/maven/plugins/frontend/lib/IncrementalMojoHelperTest.java
@@ -1,0 +1,63 @@
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+import com.github.eirslett.maven.plugins.frontend.lib.IncrementalBuildExecutionDigest.Execution;
+import org.junit.jupiter.api.Test;
+
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static com.github.eirslett.maven.plugins.frontend.lib.IncrementalMojoHelper.addTrackedFile;
+import static java.lang.Runtime.getRuntime;
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IncrementalMojoHelperTest {
+
+    @Test
+    public void shouldProcessLargeFilesAndNotCauseMemoryAllocationSpikes() throws Exception {
+        Path tempDir = Files.createTempDirectory("large-file-test");
+        Path largeFile = tempDir.resolve("large-test-file.bin");
+        final long largeFileSize = 2L * 1024 * 1024 * 1024; // 2GiB
+
+        try {
+            // Given
+            try (RandomAccessFile file = new RandomAccessFile(largeFile.toFile(), "rw")) {
+                file.setLength(largeFileSize);
+
+                file.seek(0);
+                file.write("header content".getBytes());
+                file.seek(largeFileSize - 100);
+                file.write("footer content".getBytes());
+            }
+
+            long memoryBefore = getRuntime().totalMemory() - getRuntime().freeMemory();
+            Collection<Execution.File> files = new ArrayList<>();
+            // When
+            addTrackedFile(files, largeFile);
+            long memoryAfter = getRuntime().totalMemory() - getRuntime().freeMemory();
+
+            long memoryDifference = memoryAfter - memoryBefore;
+            // Allow some tolerance for GC
+            long maxAllowedIncrease = 32 * 1024 * 1024;
+
+            // Then
+            assertTrue(memoryDifference < maxAllowedIncrease,
+                    format("Memory usage increased too much: %.2f MiB, expected less than %.2f MiB",
+                            memoryDifference / (1024 * 1024.0),
+                            maxAllowedIncrease / (1024 * 1024.0)));
+
+            assertEquals(1, files.size());
+            Execution.File processedFile = files.iterator().next();
+            assertEquals(largeFile.toString(), processedFile.filename);
+            assertEquals(largeFileSize, processedFile.byteLength);
+
+        } finally {
+            Files.deleteIfExists(largeFile);
+            Files.deleteIfExists(tempDir);
+        }
+    }
+}


### PR DESCRIPTION
This also happens to be 20% faster.

Apache commons is used in the rest of the plugin so can't get rid of it.

Tested manually that it works in Stash.