### PR TITLE
Update repo git URL to use SSH in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <scm>
         <url>https://github.com/atlassian-forks/frontend-maven-plugin</url>
-        <connection>scm:git:https://github.com/atlassian-forks/frontend-maven-plugin.git</connection>
+        <connection>scm:git:git@github.com:atlassian-forks/frontend-maven-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:atlassian-forks/frontend-maven-plugin.git</developerConnection>
       <tag>HEAD</tag>
   </scm>


### PR DESCRIPTION
Our release script uses this to reset the git remote URL, but we only have credentials for SSH setup, not HTTPS
