### PR TITLE
Post 1.15.1-atlassian-6 release (release-fb7d1db-20251218153900)

### DIFF
--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>frontend-plugins</artifactId>
     <groupId>com.github.eirslett</groupId>
-    <version>1.15.1-atlassian-6-SNAPSHOT</version>
+    <version>1.15.1-atlassian-6</version>
   </parent>
 
   <artifactId>frontend-maven-plugin</artifactId>

--- a/frontend-maven-plugin/pom.xml
+++ b/frontend-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>frontend-plugins</artifactId>
     <groupId>com.github.eirslett</groupId>
-    <version>1.15.1-atlassian-6</version>
+    <version>1.15.1-atlassian-7-SNAPSHOT</version>
   </parent>
 
   <artifactId>frontend-maven-plugin</artifactId>

--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>frontend-plugins</artifactId>
         <groupId>com.github.eirslett</groupId>
-        <version>1.15.1-atlassian-6</version>
+        <version>1.15.1-atlassian-7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/frontend-plugin-core/pom.xml
+++ b/frontend-plugin-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>frontend-plugins</artifactId>
         <groupId>com.github.eirslett</groupId>
-        <version>1.15.1-atlassian-6-SNAPSHOT</version>
+        <version>1.15.1-atlassian-6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.eirslett</groupId>
     <artifactId>frontend-plugins</artifactId>
-    <version>1.15.1-atlassian-6</version>
+    <version>1.15.1-atlassian-7-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -33,7 +33,7 @@
         <url>https://github.com/atlassian-forks/frontend-maven-plugin</url>
         <connection>scm:git:git@github.com:atlassian-forks/frontend-maven-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:atlassian-forks/frontend-maven-plugin.git</developerConnection>
-      <tag>frontend-plugins-1.15.1-atlassian-6</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.eirslett</groupId>
     <artifactId>frontend-plugins</artifactId>
-    <version>1.15.1-atlassian-6-SNAPSHOT</version>
+    <version>1.15.1-atlassian-6</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -33,7 +33,7 @@
         <url>https://github.com/atlassian-forks/frontend-maven-plugin</url>
         <connection>scm:git:git@github.com:atlassian-forks/frontend-maven-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:atlassian-forks/frontend-maven-plugin.git</developerConnection>
-      <tag>HEAD</tag>
+      <tag>frontend-plugins-1.15.1-atlassian-6</tag>
   </scm>
 
     <developers>


### PR DESCRIPTION
Keep the versions up to date

The release script was unable to push, but I don't know why considering the bot should have access to bypass: https://ecosystem-bamboo.internal.atlassian.com/browse/FMP-FMPM-FMPMRELEASE-160/log
```
18-Dec-2025 15:39:34 | Switched to branch 'master'
-- | --
18-Dec-2025 15:39:34 | Your branch is up to date with 'origin/master'.
18-Dec-2025 15:39:34 | From github.com:atlassian-forks/frontend-maven-plugin
18-Dec-2025 15:39:34 | * branch            master     -> FETCH_HEAD
18-Dec-2025 15:39:34 | Already up to date.
18-Dec-2025 15:39:34 | Updating fb7d1db..4a66d37
18-Dec-2025 15:39:34 | Fast-forward
18-Dec-2025 15:39:34 | frontend-maven-plugin/pom.xml \| 2 +-
18-Dec-2025 15:39:34 | frontend-plugin-core/pom.xml  \| 2 +-
18-Dec-2025 15:39:34 | pom.xml                       \| 2 +-
18-Dec-2025 15:39:34 | 3 files changed, 3 insertions(+), 3 deletions(-)
18-Dec-2025 15:39:35 | remote: error: GH006: Protected branch update failed for refs/heads/master.
18-Dec-2025 15:39:35 | remote:
18-Dec-2025 15:39:35 | remote: - 3 of 3 required status checks are in progress.
18-Dec-2025 15:39:35 | To github.com:atlassian-forks/frontend-maven-plugin.git
18-Dec-2025 15:39:35 | ! [remote rejected] master -> master (protected branch hook declined)
18-Dec-2025 15:39:35 | error: failed to push some refs to 'github.com:atlassian-forks/frontend-maven-plugin.git'
18-Dec-2025 15:39:35 | [RELEASE SCRIPT] An error occurred during the release process:
18-Dec-2025 15:39:35 | [RELEASE SCRIPT]
18-Dec-2025 15:39:35 | [RELEASE SCRIPT] --------------------------------------------------------------------------------
18-Dec-2025 15:39:35 | [RELEASE SCRIPT]
18-Dec-2025 15:39:35 | [RELEASE SCRIPT] Restore current git user details
18-Dec-2025 15:39:35 | node:internal/errors:932
18-Dec-2025 15:39:35 | const err = new Error(message);
18-Dec-2025 15:39:35 | ^
18-Dec-2025 15:39:35 |  
18-Dec-2025 15:39:35 | Error: Command failed: git push
18-Dec-2025 15:39:35 | at checkExecSyncError (node:child_process:890:11)
18-Dec-2025 15:39:35 | at execSync (node:child_process:962:15)
18-Dec-2025 15:39:35 | at echoExecCommandAndPrintOutput (file:///root/.npm/_npx/dab22c9a5b8e8976/node_modules/@atlassian/dc-core-release-scripts/dist/utils.js:28:5)
18-Dec-2025 15:39:35 | at gitMergeReleaseBranchBackToCurrent (file:///root/.npm/_npx/dab22c9a5b8e8976/node_modules/@atlassian/dc-core-release-scripts/dist/release.js:485:5)
18-Dec-2025 15:39:35 | at main (file:///root/.npm/_npx/dab22c9a5b8e8976/node_modules/@atlassian/dc-core-release-scripts/dist/release.js:690:9)
18-Dec-2025 15:39:35 | at file:///root/.npm/_npx/dab22c9a5b8e8976/node_modules/@atlassian/dc-core-release-scripts/dist/release.js:721:5
18-Dec-2025 15:39:35 | at ModuleJob.run (node:internal/modules/esm/module_job:218:25)
18-Dec-2025 15:39:35 | at async ModuleLoader.import (node:internal/modules/esm/loader:329:24)
18-Dec-2025 15:39:35 | at async loadESM (node:internal/process/esm_loader:28:7) {
18-Dec-2025 15:39:35 | status: 1,
18-Dec-2025 15:39:35 | signal: null,
18-Dec-2025 15:39:35 | output: [ null, null, null ],
18-Dec-2025 15:39:35 | pid: 2000,
18-Dec-2025 15:39:35 | stdout: null,
18-Dec-2025 15:39:35 | stderr: null
18-Dec-2025 15:39:35 | }
18-Dec-2025 15:39:35 |  
18-Dec-2025 15:39:35 | Node.js v20.11.0
18-Dec-2025 15:39:35 | npm verb exit 1
18-Dec-2025 15:39:35 | npm verb code 1
```